### PR TITLE
Update README and LICENSE for Release of pre-build binaries (v.1.0.0)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,159 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+This project statically links against several third-party libraries. Our prebuilt binaries therefore bundle these libraries, and their licenses are included below as required:
+
+---
+
+OpenBLAS License (BSD 3-Clause)
+
+Copyright (c) 2011-2014, The OpenBLAS Project  
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. Neither the name of the OpenBLAS project nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---
+
+LAPACK License (Modified BSD)
+
+Copyright (c) 1992-2025 The University of Tennessee and The University
+                         of Tennessee Research Foundation.  All rights
+                         reserved.
+Copyright (c) 2000-2025 The University of California Berkeley. All
+                         rights reserved.
+Copyright (c) 2006-2025 The University of Colorado Denver.  All rights
+                         reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer listed
+  in this license in the documentation and/or other materials
+  provided with the distribution.
+
+- Neither the name of the copyright holders nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+The copyright holders provide no reassurances that the source code
+provided does not infringe any patent, copyright, or any other
+intellectual property rights of third parties.  The copyright holders
+disclaim any liability to any recipient for claims brought against
+recipient by any third party for infringement of that parties
+intellectual property rights.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---
+
+pybind11 License (BSD 3-Clause)
+
+Copyright (c) 2016 Wenzel Jakob <wenzel.jakob@epfl.ch>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions, and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions, and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the author nor the names of any contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+NLopt License (MIT)
+
+Copyright (c) 2007-2014 Massachusetts Institute of Technology
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+Note: Built without Luksan routines to remain MIT compatible
+
+---
+
+Armadillo License (Apache 2.0)
+
+Copyright 2008-2023 Conrad Sanderson (http://conradsanderson.id.au)
+Copyright 2008-2016 National ICT Australia (NICTA)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,29 @@
-## Code Structure:
+# ITPAL
+
+ITPAL provides efficient implementations for KL-divergence based projections of Gaussians. This package focuses specifically on the projection operations, optimized through C++ and parallelized using OpenMP and provides low level bindings for them. For JAX bindings see [ITPAL_JAX](https://github.com/ALRhub/ITPAL_JAX).
+
+# Installation
+
+## From Pre-built Binaries (Recommended)
+
+We now provide pre-built binaries that should work on all systems if:
+ - Hardware is 64-bit Intel or AMD and from 2009+
+ - OS is Linux with glibc 2.17+ (from 2014+) following FHS (includes Ubuntu/Debian/Fedora/CentOS/...)
+ - Python 3.6-3.12
+ - gfortran 10+ is installed (e.g. `sudo apt-get install gfortran`, already installed on BwUni2 & HoReKa)
+ - OpenMP is installed (optional, but increases performance of batched projections, already installed on BwUni2 & HoReKa)
+
+Download the appropriate wheel for your Python version from the [releases](https://github.com/ALRhub/ITPAL/releases) page and install with pip:
+
+```bash
+pip install cpp_projection-{version}-cp{python_version}-manylinux2014_x86_64.whl
+```
+
+## Manual Installation (Legacy Method)
+
+If you prefer to build from source or the pre-built binaries don't work for your system, you can follow the manual installation instructions below.
+
+### Code Structure:
 
 ##### python:
    
@@ -10,15 +35,15 @@ containes tuned implementation for non-batched projection (MoreProjection.cpp/h)
  
  Interface to python is provided using pybind11 (PyProject.cpp), conversion for numpy arrays to aramdillo vec/mat/ cube is provided
  in PyArmaConverter.h
-    
+
 Note that the C++ part uses column-major layout while the python part uses row-major
 
-## Setup python
+### Setup python
 Tested with python 3.6.8 
 
 Dependencies: numpy, nlopt
 
-## Setup c++
+### Setup c++
 ##### 1. Install required packages and libraries 
 Install required packages into your conda environment
 
@@ -28,3 +53,16 @@ Install required packages into your conda environment
 go to `ITPAL/cpp/` and run 
 
 ```python3 setup.py install --user```
+
+## License
+
+This project, including all code, documentation, and provided binaries is licensed under the MIT License. See the [LICENSE file](LICENSE) for details.
+
+### 3rd Party Licenses
+The following 3rd party libraries are statically linked into cpp_projection binaries:
+- OpenBLAS
+- LAPACK
+- NLOPT (without LGPL parts to remain MIT compatible)
+- Armadillo
+
+You can find the licenses of these libraries in the [LICENSE file](LICENSE).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ We now provide pre-built binaries that should work on all systems if:
 Download the appropriate wheel for your Python version from the [releases](https://github.com/ALRhub/ITPAL/releases) page and install with pip:
 
 ```bash
-pip install cpp_projection-{version}-cp{python_version}-manylinux2014_x86_64.whl
+pip install cpp_projection-{version}-{python_version_name}-manylinux2014_x86_64.whl
 ```
 
 ## Manual Installation (Legacy Method)


### PR DESCRIPTION
This PR accompanies the 1.0.0 release of pre-built binaries

## Changes
- Updated README with new recommended installation instructions using pre-built binaries.
- Added licenses of statically linked dependencies to LICENSE file (OpenBLAS, LAPACK, NLOPT, Armadillo)
  since our binaries bundle these.

Get more info on the 1.0.0 Release and grab the new pre-built binaries from the [releases](https://github.com/ALRhub/ITPAL/releases) page.